### PR TITLE
Enabling enbsubst cmd via gettext-base package

### DIFF
--- a/jenkins-dind-slave/Dockerfile
+++ b/jenkins-dind-slave/Dockerfile
@@ -10,6 +10,7 @@ ENV PACKER_VERSION "0.9.0"
 # Let's start with some basic stuff.
 RUN apt-get update -qq && apt-get install -qqy \
   apt-transport-https \
+  gettext-base \
   ca-certificates \
   lxc \
   iptables \


### PR DESCRIPTION
`envsubst` can be used for replacing environment variables with values in `FROM` stmt of Dockerfile. 