### PR TITLE
Docker 17.06

### DIFF
--- a/amazon-ecr-credential-helper/Dockerfile
+++ b/amazon-ecr-credential-helper/Dockerfile
@@ -1,0 +1,33 @@
+##### Intermediate source code layer
+MAINTAINER "base2Services" <itsupport@base2services.com>
+FROM alpine:latest as source
+
+ARG SOURCE_SHA1="16f099b"
+ENV SHA1 $SOURCE_SHA1
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh make
+
+RUN mkdir /src
+RUN git clone https://github.com/awslabs/amazon-ecr-credential-helper.git /src
+
+RUN cd /src \
+    git checkout $SHA1
+
+#### ecr helper is built using go
+
+FROM golang:1.8-alpine as binaries
+
+COPY --from=source /src /go/src/github.com/awslabs/amazon-ecr-credential-helper
+
+# make and bash are dependencies for built system
+RUN apk update && apk upgrade && \
+    apk add --no-cache make bash
+
+RUN cd /go/src/github.com/awslabs/amazon-ecr-credential-helper \
+      && make \
+      && cp bin/local/docker-credential-ecr-login /bin
+
+FROM scratch
+
+COPY --from=binaries /bin/docker-credential-ecr-login /bin/docker-credential-ecr-login

--- a/jenkins-dind-slave/Dockerfile
+++ b/jenkins-dind-slave/Dockerfile
@@ -1,9 +1,10 @@
 # This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node.
+FROM base2/amazon-ecr-credential-helper:latest as amazon-ecr-credential-helper
 FROM java:openjdk-8-jdk
-MAINTAINER Aaron Walker <a.walker@base2services.com>
+MAINTAINER "base2Services" <itsupport@base2services.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DOCKER_VERSION "1.9.1"
+ENV DOCKER_VERSION "17.06.0-ce"
 ENV CHEFDK_VERSION "1.2.22-1"
 ENV PACKER_VERSION "0.12.2"
 
@@ -31,7 +32,8 @@ RUN apt-get update -qq && apt-get install -qqy \
   && adduser --quiet jenkins && echo "jenkins:jenkins" | chpasswd \
   && echo "jenkins ALL = NOPASSWD: ALL" > /etc/sudoers.d/jenkins \
   && usermod -a -G root jenkins \
-  && curl -sSL "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}" > /usr/bin/docker && chmod +x /usr/bin/docker \
+  && curl "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" > /tmp/docker.tgz \
+  && tar -xf /tmp/docker.tgz -C /tmp && mv /tmp/docker/* /bin && rm -rf /tmp/docker* \
   && curl -kL "https://packages.chef.io/stable/debian/6/chefdk_${CHEFDK_VERSION}_amd64.deb" > /tmp/chefdk.deb \
   && dpkg -i /tmp/chefdk.deb \
   && curl -L "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" > /tmp/packer.zip \
@@ -42,6 +44,11 @@ RUN apt-get update -qq && apt-get install -qqy \
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get install -y --no-install-recommends git-lfs && \
     git lfs install
+
+# Install and configure amazon-ecr-credentials helper
+COPY --from=amazon-ecr-credential-helper /bin/docker-credential-ecr-login /bin/docker-credential-ecr-login
+COPY docker.config.json /root/.docker/config.json
+COPY docker.config.json /home/jenkins/.docker/config.json
 
 EXPOSE 22
 

--- a/jenkins-dind-slave/docker.config.json
+++ b/jenkins-dind-slave/docker.config.json
@@ -1,0 +1,3 @@
+{
+	"credsStore": "ecr-login"
+}

--- a/jenkins-dind-slave/jenkins-docker-slave.sh
+++ b/jenkins-dind-slave/jenkins-docker-slave.sh
@@ -3,7 +3,7 @@ set -e
 
 /usr/sbin/sshd -D &
 
-docker daemon \
+/bin/dockerd \
 	--host=unix:///var/run/docker.sock \
 	--storage-driver=vfs \
 	"$@"

--- a/jenkins/2/plugins.txt
+++ b/jenkins/2/plugins.txt
@@ -104,3 +104,4 @@ handlebars
 javadoc
 run-condition
 next-build-number
+multiple-scms


### PR DESCRIPTION
### Docker version

 Docker version has been updated to 17.06.0-ce for jenkins-diind-slave. This enables multi-stage builds and other features from latest docker build 

### Amazon ecr helper
New container has been added - amazon-ecr-credential-helper. It is envisioned to be data-container used in other container builds. More specifically `jenkins-diind-slave` uses copies binary from this container. This will remove need for manually logging into ECR repositories during docker builds, and when pushing to ecr repository

### Jenkins plugins
MultiSCM plugin has been added to list of jenkins plugins. 