### PR TITLE
Docker version and credentials helper

### DIFF
--- a/jenkins-dind-slave/Dockerfile
+++ b/jenkins-dind-slave/Dockerfile
@@ -3,8 +3,11 @@ FROM base2/amazon-ecr-credential-helper:latest as amazon-ecr-credential-helper
 FROM java:openjdk-8-jdk
 MAINTAINER "base2Services" <itsupport@base2services.com>
 
+ARG USE_ECR_CREDENTIAL_HELPER="0"
+
+ENV USE_ECR_CREDENTIAL_HELPER $USE_ECR_CREDENTIAL_HELPER
 ENV DEBIAN_FRONTEND noninteractive
-ENV DOCKER_VERSION "17.06.0-ce"
+ENV DOCKER_VERSION "17.03.2-ce"
 ENV CHEFDK_VERSION "1.2.22-1"
 ENV PACKER_VERSION "0.12.2"
 
@@ -47,8 +50,8 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
 
 # Install and configure amazon-ecr-credentials helper
 COPY --from=amazon-ecr-credential-helper /bin/docker-credential-ecr-login /bin/docker-credential-ecr-login
-COPY docker.config.json /root/.docker/config.json
-COPY docker.config.json /home/jenkins/.docker/config.json
+COPY setup_ecr_credentials_helper.sh /bin/setup_ecr_credentials_helper
+RUN chmod a+x /bin/setup_ecr_credentials_helper
 
 EXPOSE 22
 

--- a/jenkins-dind-slave/docker.config.json
+++ b/jenkins-dind-slave/docker.config.json
@@ -1,3 +1,0 @@
-{
-	"credsStore": "ecr-login"
-}

--- a/jenkins-dind-slave/jenkins-docker-slave.sh
+++ b/jenkins-dind-slave/jenkins-docker-slave.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+setup_ecr_credentials_helper
+
 /usr/sbin/sshd -D &
 
 /bin/dockerd \

--- a/jenkins-dind-slave/setup_ecr_credentials_helper.sh
+++ b/jenkins-dind-slave/setup_ecr_credentials_helper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [ "$USE_ECR_CREDENTIAL_HELPER" == "1" ]; then
+  cat > /root/docker.config.ecr.json << EOF
+  {
+  	 "credsStore": "ecr-login"
+  }
+EOF
+  mkdir /root/.docker
+  mkdir -p home/jenkins/.docker
+  cp /root/docker.config.ecr.json /root/.docker/config.json
+  cp /root/docker.config.ecr.json /home/jenkins/.docker/config.json
+  chown -R 1000:1000 /home/jenkins/.docker
+  rm /root/docker.config.ecr.json
+fi


### PR DESCRIPTION
- Docker version defaults to `17.03.2-ce`
- Amazon ecr credentials helper is not used by default. It can be enabled by passing env var `USE_ECR_CREDENTIAL_HELPER=1`