### PR TITLE
Slave using tini, plugins update, override entrypoint for server

### DIFF
--- a/jenkins-docker-slave/Dockerfile
+++ b/jenkins-docker-slave/Dockerfile
@@ -1,5 +1,6 @@
 # This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node.
 FROM base2/amazon-ecr-credential-helper:latest as amazon-ecr-credential-helper
+
 FROM java:openjdk-8-jdk
 MAINTAINER "base2Services" <itsupport@base2services.com>
 
@@ -55,10 +56,15 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
 # Install and configure amazon-ecr-credentials helper
 COPY --from=amazon-ecr-credential-helper /bin/docker-credential-ecr-login /bin/docker-credential-ecr-login
 COPY setup_ecr_credentials_helper.sh /bin/setup_ecr_credentials_helper
-RUN chmod a+x /bin/setup_ecr_credentials_helper
+COPY jenkins-docker-slave.sh  /usr/local/bin/jenkins-docker-slave.sh
+RUN chmod a+x /bin/setup_ecr_credentials_helper; \
+    chmod a+x /usr/local/bin/jenkins-docker-slave.sh
 
 EXPOSE 22
 
-COPY jenkins-docker-slave.sh /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/jenkins-docker-slave.sh"]
-CMD []
+ENV TINI_VERSION v0.15.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["/usr/local/bin/jenkins-docker-slave.sh"]

--- a/jenkins-docker-slave/jenkins-docker-slave.sh
+++ b/jenkins-docker-slave/jenkins-docker-slave.sh
@@ -15,8 +15,11 @@ if [ "$RUN_DOCKER_IN_DOCKER" == "1" ]; then
         --storage-driver=vfs \
         "$@"
 else
-    if [ -f "/var/run/docker.sock" ]; then
-      chown 1000:1000 /var/run/docker.sock
+    if [ -S "/var/run/docker.sock" ]; then
+      docker_gid=$(ls -la /var/run/docker.sock | awk '{print $4}')
+      groupadd -g $docker_gid docker
+      usermod -a -G docker jenkins
+      echo "Added group docker with id $docker_gid and added jenkins user to it"
     fi
     if [ -d "/data/jenkins-dood" ]; then
       chown 1000:1000 /data/jenkins-dood

--- a/jenkins-docker-slave/jenkins-docker-slave.sh
+++ b/jenkins-docker-slave/jenkins-docker-slave.sh
@@ -3,6 +3,10 @@ set -e
 
 setup_ecr_credentials_helper
 
+if [ -f "/var/run/docker.pid" ];then
+  rm /var/run/docker.pid
+fi
+
 if [ "$RUN_DOCKER_IN_DOCKER" == "1" ]; then
     /usr/sbin/sshd -D &
 
@@ -11,8 +15,12 @@ if [ "$RUN_DOCKER_IN_DOCKER" == "1" ]; then
         --storage-driver=vfs \
         "$@"
 else
-    chown 1000:1000 /var/run/docker.sock
-    chown 1000:1000 /data/jenkins-dood
-    usermod -d /data/jenkins-dood jenkins
+    if [ -f "/var/run/docker.sock" ]; then
+      chown 1000:1000 /var/run/docker.sock
+    fi
+    if [ -d "/data/jenkins-dood" ]; then
+      chown 1000:1000 /data/jenkins-dood
+      usermod -d /data/jenkins-dood jenkins
+    fi
     /usr/sbin/sshd -D
 fi

--- a/jenkins/2/Dockerfile
+++ b/jenkins/2/Dockerfile
@@ -2,3 +2,7 @@ FROM jenkins:2.46.3
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 COPY custom.groovy /usr/share/jenkins/ref/init.groovy.d/custom.groovy
 RUN /usr/local/bin/install-plugins.sh $(cat /usr/share/jenkins/ref/plugins.txt)
+
+COPY entrypoint.sh /bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/tini","--","/bin/entrypoint.sh"]

--- a/jenkins/2/custom.groovy
+++ b/jenkins/2/custom.groovy
@@ -137,3 +137,5 @@ if (!bootstrap) {
 } else {
   println("Bootstrap file present, this is not first execution of this file")
 }
+
+println "\nCIINABOX - Jenkins initialization complete at ${new java.util.Date()}\n"

--- a/jenkins/2/entrypoint.sh
+++ b/jenkins/2/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# If init file exists, needs to be overwritten
+# as jenkins exntrypoint does not handle this situation
+# (does not care if init script is updated on)
+if [ -f "/var/jenkins_home/init.groovy.d/custom.groovy" ];then
+  echo "Updating Jenkins init script in /usr/share/jenkins/ref/init.groovy.d/custom.groovy ..."
+  cp /usr/share/jenkins/ref/init.groovy.d/custom.groovy /var/jenkins_home/init.groovy.d/custom.groovy
+fi
+
+/usr/local/bin/jenkins.sh

--- a/jenkins/2/plugins.txt
+++ b/jenkins/2/plugins.txt
@@ -81,7 +81,7 @@ pipeline-input-step
 workflow-basic-steps
 workflow-multibranch
 workflow-scm-step
-workflow-job:2.11
+workflow-job
 workflow-durable-task-step
 workflow-step-api
 pipeline-build-step


### PR DESCRIPTION
1.  Jenkins server has overriden entrypoint. This enables custom script that copies Jenkins init script to designed location. This is useful when jenkins init script is updated and ciinabox is updated - new init script will be executed in such scenario, which was not the case so far

2. Removed plugin version constraints, as all of blue ocean plugins latest versions are now compatible with workflow-job plugin latest version, which was constrained

3. Jenkins slave is running using tini - https://github.com/krallin/tini

4. Bugfix - when starting docker slave in docker outside of docker mode, docker socket file is tested for group id, docker group is added under this id, and jenkins user added to docker group