### PR TITLE
Handle docker group when mounting with existing gid

### DIFF
--- a/jenkins-docker-slave/setup_ecr_credentials_helper.sh
+++ b/jenkins-docker-slave/setup_ecr_credentials_helper.sh
@@ -7,9 +7,10 @@ if [ "$USE_ECR_CREDENTIAL_HELPER" == "1" ]; then
   }
 EOF
   mkdir /root/.docker
-  mkdir -p home/jenkins/.docker
+  jenkins_home=$(cat /etc/passwd | grep jenkins | cut -d: -f6)
+  mkdir -p $jenkins_home/.docker
   cp /root/docker.config.ecr.json /root/.docker/config.json
-  cp /root/docker.config.ecr.json /home/jenkins/.docker/config.json
-  chown -R 1000:1000 /home/jenkins/.docker
+  cp /root/docker.config.ecr.json $jenkins_home/.docker/config.json
+  chown -R 1000:1000 $jenkins_home/.docker
   rm /root/docker.config.ecr.json
 fi


### PR DESCRIPTION
If groupid for group having ownership over `/var/run/docker.sock` socket file on docker host is existing groupid on slave, system startup failure will occur. Only registered case is due  testing images locally on MacOS, but there are no reported occurrences on Amazon ECS hosts. 

 Workaround is to remove group matching owner id from host during slave startup. As jenkins groupid is 1000, and system groups are always with id < 1000, there is no danger of deleting jenkins group as long as docker socket file is owned by system user. 

Also, this PR is fixing bug with amazon ecr credentials helper in "dood" mode for docker slave, as home directory is altered in this case. 