### PR TITLE
Allow setting diind storage driver

### DIFF
--- a/jenkins-docker-slave/Dockerfile
+++ b/jenkins-docker-slave/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER "base2Services" <itsupport@base2services.com>
 # Default to not using credentials helper and docker 17.03.2-ce
 ARG USE_ECR_CREDENTIAL_HELPER="0"
 ARG DOCKER_VERSION="17.03.2-ce"
-
+ARG DOCKER_STORAGE_DRIVER="vfs"
 ENV USE_ECR_CREDENTIAL_HELPER $USE_ECR_CREDENTIAL_HELPER
 ENV DOCKER_VERSION $DOCKER_VERSION
 
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ENV CHEFDK_VERSION "2.4.17"
 ENV PACKER_VERSION "1.1.3"
+ENV DOCKER_STORAGE_DRIVER $DOCKER_IN_DOCKER_STORAGE_DRIVER
 
 # Let's start with some basic stuff.
 RUN apt-get update -qq && apt-get install -qqy \

--- a/jenkins-docker-slave/jenkins-docker-slave.sh
+++ b/jenkins-docker-slave/jenkins-docker-slave.sh
@@ -12,7 +12,7 @@ if [ "$RUN_DOCKER_IN_DOCKER" == "1" ]; then
 
     /bin/dockerd \
         --host=unix:///var/run/docker.sock \
-        --storage-driver=vfs \
+        --storage-driver=$DOCKER_STORAGE_DRIVER \
         "$@"
 else
     if [ -S "/var/run/docker.sock" ]; then


### PR DESCRIPTION
# Problem

CIinabox docker-in-docker slave runs under vfs storage driver which is not for production loads, and very slow for building container images. There should be option to us

# Solution

Docker storage driver is passed in to docker slave container as build arg, e.g. 
` docker build -t base2/ciinabox-docker-slave:17.09.0-ce-overlay --build-arg DOCKER_VERSION=17.09.0-ce --build-arg=DOCKER_STORAGE_DRIVER=overlay .`



