### PR TITLE
Remove explicit tini

### DIFF
--- a/jenkins/lts/Dockerfile
+++ b/jenkins/lts/Dockerfile
@@ -5,4 +5,4 @@ RUN /usr/local/bin/install-plugins.sh $(cat /usr/share/jenkins/ref/plugins.txt)
 
 COPY entrypoint.sh /bin/entrypoint.sh
 
-ENTRYPOINT ["/bin/tini","--","/bin/entrypoint.sh"]
+ENTRYPOINT ["/bin/entrypoint.sh"]


### PR DESCRIPTION
Upstream `lts` image removed tini from its implementation, as starting from Docker 1.13 tini is part of docker itself. This fixes broken build due missing binary file. 